### PR TITLE
Feat: Clearer error handling for convex user webhook

### DIFF
--- a/frontend/convex/http.ts
+++ b/frontend/convex/http.ts
@@ -50,9 +50,15 @@ http.route({
 
       return new Response("Successful user event", { status: 200 });
     } catch (error) {
-      const convexError = error instanceof ConvexError;
+      if (error instanceof ConvexError) {
+        const msg = error.message;
 
-      if (convexError) return new Response("ALREADY EXISTS", { status: 409 });
+        if (msg.includes("USER_NOT_FOUND")) {
+          return new Response("User not found", { status: 404 });
+        } else if (msg.includes("USAGE_NOT_FOUND")) {
+          return new Response("Usage not found", { status: 404 });
+        }
+      }
 
       return new Response("Error occurred", { status: 500 });
     }

--- a/frontend/convex/users.ts
+++ b/frontend/convex/users.ts
@@ -44,7 +44,8 @@ export const deleteUser = internalMutation({
       .withIndex("by_ExternalId", (q) => q.eq("externalId", externalId))
       .unique();
 
-    if (userByExternalId === null) throw new ConvexError("User not found");
+    if (userByExternalId === null)
+      throw new ConvexError("[deleteUser]: USER_NOT_FOUND");
 
     const chats = await ctx.db
       .query("chats")
@@ -98,7 +99,7 @@ export const deleteUser = internalMutation({
       .unique();
 
     if (usageRecord === null)
-      throw new ConvexError("Failed to find user usage record");
+      throw new ConvexError("[deleteUser]: USAGE_NOT_FOUND");
 
     await ctx.db.delete(usageRecord._id);
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR improves error handling for the Clerk user webhook by replacing generic error messages with structured error codes.

**Key changes:**
- Added structured error messages in `deleteUser` mutation with format `[functionName]: ERROR_CODE`
- Updated webhook error handler to parse error codes and return appropriate HTTP status codes (404 for not found errors)
- Replaced generic 409 Conflict response with specific 404 Not Found for `USER_NOT_FOUND` and `USAGE_NOT_FOUND` errors

**Minor concerns:**
- String matching with `.includes()` is fragile and could lead to false positives
- HTTP status code changed from 409 to 404 for these error cases - verify this doesn't break external integrations

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor considerations about API contract changes
- The changes are well-structured and improve error handling clarity. String matching approach is slightly fragile but functional. Main consideration is the HTTP status code change from 409 to 404.
- frontend/convex/http.ts - verify the status code change doesn't break integrations

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| frontend/convex/http.ts | Improved error handling with specific status codes for user and usage not found errors |
| frontend/convex/users.ts | Added structured error messages with function prefixes and error codes for better debugging |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Clerk
    participant Webhook as Clerk Webhook Handler
    participant DeleteUser as deleteUser Mutation
    participant DB as Convex Database

    Clerk->>Webhook: POST /clerk-users-webhook
    Note over Webhook: Validate request with Svix
    
    alt user.deleted event
        Webhook->>DeleteUser: runMutation(deleteUser, externalId)
        DeleteUser->>DB: Query user by externalId
        
        alt User not found
            DB-->>DeleteUser: null
            DeleteUser-->>Webhook: throw ConvexError("[deleteUser]: USER_NOT_FOUND")
            Webhook-->>Clerk: 404 User not found
        else User exists
            DB-->>DeleteUser: userByExternalId
            DeleteUser->>DB: Delete chats, messages, invites, etc.
            DeleteUser->>DB: Query usage record
            
            alt Usage not found
                DB-->>DeleteUser: null
                DeleteUser-->>Webhook: throw ConvexError("[deleteUser]: USAGE_NOT_FOUND")
                Webhook-->>Clerk: 404 Usage not found
            else Usage exists
                DB-->>DeleteUser: usageRecord
                DeleteUser->>DB: Delete usage, keys, files, user
                DeleteUser-->>Webhook: Success
                Webhook-->>Clerk: 200 Successful user event
            end
        end
    else user.created or user.updated
        Webhook->>Webhook: runMutation(upsertUser)
        Webhook-->>Clerk: 200 Successful user event
    end
    
    Note over Webhook: Catch block handles ConvexError<br/>with string matching on error message
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->