### PR TITLE
Feat: Usage updates after success on message send

### DIFF
--- a/frontend/src/app/(root)/components/ChatView/MessageInput/message-input.tsx
+++ b/frontend/src/app/(root)/components/ChatView/MessageInput/message-input.tsx
@@ -268,11 +268,6 @@ export default function MessageInput({
       modelId: selectedModel.id,
     });
 
-    await updateUsage({
-      usageId: usage._id,
-      credits: usage.messagesRemaining - 1,
-    });
-
     try {
       await complete(
         JSON.stringify({
@@ -282,6 +277,11 @@ export default function MessageInput({
           messageId: messageId,
         }),
       );
+
+      await updateUsage({
+        usageId: usage._id,
+        credits: usage.messagesRemaining - 1,
+      });
     } catch (error) {
       if (error instanceof DOMException && error.name === "AbortError") {
         // This is a user-initiated abort - should be handled as success


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes when user credits are decremented during message submission by moving the `updateUsage` mutation to run only after `complete()` resolves successfully.

This fits into the existing message-send flow in `MessageInput`: it saves the user message, creates an assistant message placeholder, calls `complete()` to stream/produce the assistant response, and then updates usage. The main behavioral impact is that failed requests (including user aborts) no longer decrement credits.

Potential issue: the abort handling comment indicates aborts should be treated as success, but with the current placement, an abort will skip `updateUsage`, which may not match intended billing semantics.

<h3>Confidence Score: 3/5</h3>

- Mostly safe to merge, but credit/usage semantics around aborts may be incorrect.
- Change is small and localized, but it touches billing/credit decrement logic; current behavior appears inconsistent with the code comment and can lead to undercounting usage on aborts.
- frontend/src/app/(root)/components/ChatView/MessageInput/message-input.tsx (abort vs success usage decrement)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| frontend/src/app/(root)/components/ChatView/MessageInput/message-input.tsx | Moves usage decrement to after `complete()` resolves; verify abort/error paths still align with intended billing semantics. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant UI as MessageInput UI
  participant Convex as Convex mutations
  participant API as /api/chats
  participant AI as complete()

  UI->>UI: handleSendMessageRoute()
  alt no activeChat
    UI->>API: POST /api/chats (history)
    API-->>UI: chat_id
  else has activeChat
    UI->>UI: chat_id = activeChat.id
  end
  UI->>Convex: saveUserMessage(chatId, newMsg, modelId)
  UI->>Convex: initiateMessage(chatId, modelId)
  UI->>AI: complete({model, encryptedApiKey, history, messageId})
  alt complete resolves
    UI->>Convex: updateUsage(usageId, messagesRemaining - 1)
  else complete throws
    UI-->>UI: skip updateUsage (current code)
  end
  UI-->>UI: clear message & uploadedFiles
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->